### PR TITLE
erlang:now() deprecated -> using erlang:timestamp()

### DIFF
--- a/src/auth/dbus_auth_cookie_sha1.erl
+++ b/src/auth/dbus_auth_cookie_sha1.erl
@@ -41,7 +41,7 @@ challenge(_, _) ->
 %%% Priv
 %%%
 calc_challenge() ->
-    {MegaSecs, Secs, _MicroSecs} = now(),
+    {MegaSecs, Secs, _MicroSecs} = erlang:timestamp(),
     UnixTime = MegaSecs * 1000000 + Secs,
     BinTime = integer_to_binary(UnixTime),
     dbus_hex:to(<<"Hello ", BinTime/binary>>).


### PR DESCRIPTION
Current version does not compiles on Erlang/OTP 18 due to usage of `erlang:now()`. I've replaced it with `erlang:timestamp()` as advised here: http://www.erlang.org/doc/apps/erts/time_correction.html