### PR TITLE
Unix domain socket implementation 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,6 @@ sudo: false
 
 language: erlang
 otp_release:
-   - 18.1
-   - 18.2.1
    - 19.0
 
 addons:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ language: erlang
 otp_release:
    - 18.1
    - 18.2.1
+   - 19.0
 
 addons:
   apt:

--- a/Makefile
+++ b/Makefile
@@ -2,12 +2,10 @@ version = 0.1
 PROJECT = dbus
 PROJECT_VERSION = $(shell git describe --always --tags 2> /dev/null || echo $(version))
 
-DEPS = inert procket edown
+DEPS = edown
 #DEPS += annotations
 #DEP_PLUGINS = annotations
 
-dep_procket = git https://github.com/msantos/procket.git 0.7.0
-dep_inert = git https://github.com/msantos/inert.git 0.6.2
 dep_annotations_commit = 9f8a800
 
 EDOC_OPTS = {app_default, "http://www.erlang.org/doc/"} \

--- a/src/dbus_transport_unix.erl
+++ b/src/dbus_transport_unix.erl
@@ -12,7 +12,6 @@
 -behaviour(gen_server).
 
 -include("dbus.hrl").
--include_lib("procket/include/procket.hrl").
 
 %% api
 -export([connect/2]).
@@ -33,39 +32,30 @@
 		loop     :: pid(),
 		raw      :: boolean()}).
 
+-define(DEFAULT_PATH, "/tmp/erlang-dbus").
+
 connect(BusOptions, _Options) ->
     Path = case proplists:get_value(path, BusOptions) of
 	       undefined ->
-		   case proplists:get_value(abstract, BusOptions) of
-		       undefined ->
-			   throw(no_path);
-		       V ->
-			   {abstract, list_to_binary(V)}
-		   end;
+                   throw(no_path);
 	       V ->
-		   {path, list_to_binary(V)}
+		   list_to_binary(V)
 	   end,
     gen_server:start_link(?MODULE, [Path, self()],[]).
 
 %%
 %% gen_server callbacks
 %%
-init([{Mode, Path}, Owner]) when is_pid(Owner), is_binary(Path) ->
+init([Path, Owner]) when is_pid(Owner), is_binary(Path) ->
     true = link(Owner),
     ?debug("Connecting to UNIX socket: ~p~n", [Path]),
-    ok = inert:start(),
-    case procket:socket(?PF_LOCAL, ?SOCK_STREAM, 0) of
+    {ok, S} = prim_inet:open(tcp, local, stream),
+    {ok, Fd} = prim_inet:getfd(S),
+    case gen_tcp:connect({local, Path}, 0, [{fd, Fd}]) of
 	{ok, Sock} ->
-	    SockUn = get_sock_un(Mode, Path),
-	    case procket:connect(Sock, SockUn) of
-		ok ->
-		    process_flag(trap_exit, true),
-		    Loop = spawn_link(?MODULE, do_read, [Sock, self()]),
-		    {ok, #state{sock=Sock, owner=Owner, loop=Loop}};
-		{error, Err} ->
-		    ?error("Error connecting socket: ~p~n", [Err]),
-		    {error, Err}
-	    end;
+            Loop = spawn_link(?MODULE, do_read, [Sock, self()]),
+            gen_tcp:controlling_process(Sock, Loop),
+            {ok, #state{sock=Sock, owner=Owner, loop=Loop}};
 	{error, Err} ->
 	    ?error("Error creating socket: ~p~n", [Err]),
 	    {error, Err}
@@ -92,8 +82,8 @@ handle_cast({send, Data}, State) when is_list(Data) ->
     handle_cast({send, iolist_to_binary(Data)}, State);
 
 handle_cast({send, Data}, #state{sock=Sock}=State) when is_binary(Data) ->
-    %%?debug("unix send(~p)~n", [Data]),
-    procket:sendto(Sock, Data, 0, <<>>),
+    ?debug("unix send(~p)~n", [Data]),
+    gen_tcp:send(Sock, Data),
     {noreply, State};
 
 handle_cast(close, State) ->
@@ -106,9 +96,8 @@ handle_cast(Request, State) ->
     ?error("Unhandled cast in ~p: ~p~n", [?MODULE, Request]),
     {noreply, State}.
 
-
 handle_info({unix, Data}, #state{owner=Owner}=State) ->
-    %%?debug("unix received(~p)~n", [Data]),
+    ?debug("unix received(~p)~n", [Data]),
     Owner ! {received, Data},
     {noreply, State};
 
@@ -121,7 +110,6 @@ handle_info(Info, State) ->
     ?error("Unhandled info in ~p: ~p~n", [?MODULE, Info]),
     {noreply, State}.
 
-
 terminate(_Reason, #state{sock=Sock, loop=Loop}) ->
     case Sock of
 	undefined -> ignore;
@@ -129,7 +117,7 @@ terminate(_Reason, #state{sock=Sock, loop=Loop}) ->
 	    exit(Loop, kill),
 	    %% Avoid do_read loop polling on closed fd
 	    timer:sleep(100),
-	    procket:close(Sock)
+            gen_tcp:close(Sock)
     end,
     ok.
 
@@ -137,26 +125,11 @@ terminate(_Reason, #state{sock=Sock, loop=Loop}) ->
 %%% Priv
 %%%
 do_read(Sock, Pid) ->
-    case procket:recvfrom(Sock, 16#FFFF) of
-	{error, eagain} ->
-	    {ok, read} = inert:poll(Sock, [{mode, read}]),
-	    do_read(Sock, Pid);
-	{error, _Err} ->
-	    ok;
-	%% EOF
-	{ok, <<>>} ->
-	    ok;
-	{ok, Buf} ->
-	    Pid ! {unix, Buf},
-	    do_read(Sock, Pid)
+    receive
+        {tcp, Sock, Buf} ->
+            Pid ! {unix, list_to_binary(Buf)},
+            do_read(Sock, Pid);
+        Unhandled ->
+            ?debug("Unhandled receive: ~p", [Unhandled]),
+            do_read(Sock, Pid)
     end.
-
-get_sock_un(abstract, Path) when byte_size(Path) < ?UNIX_PATH_MAX-1 ->
-    Len = byte_size(Path),
-    <<(procket:sockaddr_common(?PF_LOCAL, Len))/binary,
-      0, Path/binary>>;
-get_sock_un(path, Path) when byte_size(Path) < ?UNIX_PATH_MAX ->
-    Len = byte_size(Path),
-    <<(procket:sockaddr_common(?PF_LOCAL, Len))/binary,
-      Path/binary, 
-      0:((procket:unix_path_max()-Len)*8)>>.

--- a/src/dbus_transport_unix.erl
+++ b/src/dbus_transport_unix.erl
@@ -51,7 +51,7 @@ init([Path, Owner]) when is_pid(Owner), is_binary(Path) ->
     ?debug("Connecting to UNIX socket: ~p~n", [Path]),
     {ok, S} = prim_inet:open(tcp, local, stream),
     {ok, Fd} = prim_inet:getfd(S),
-    case gen_tcp:connect({local, Path}, 0, [{fd, Fd}]) of
+    case gen_tcp:connect({local, Path}, 0, [{fd, Fd}, {recbuf, 65535}]) of
 	{ok, Sock} ->
             Loop = spawn_link(?MODULE, do_read, [Sock, self()]),
             gen_tcp:controlling_process(Sock, Loop),

--- a/src/dbus_transport_unix.erl
+++ b/src/dbus_transport_unix.erl
@@ -27,7 +27,7 @@
 %% Internal
 -export([do_read/2]).
 
--record(state, {sock, 
+-record(state, {sock,
 		owner,
 		loop     :: pid(),
 		raw      :: boolean()}).
@@ -113,7 +113,7 @@ handle_info(Info, State) ->
 terminate(_Reason, #state{sock=Sock, loop=Loop}) ->
     case Sock of
 	undefined -> ignore;
-	_ -> 
+	_ ->
 	    exit(Loop, kill),
 	    %% Avoid do_read loop polling on closed fd
 	    timer:sleep(100),

--- a/src/dbus_transport_unix.erl
+++ b/src/dbus_transport_unix.erl
@@ -82,7 +82,7 @@ handle_cast({send, Data}, State) when is_list(Data) ->
     handle_cast({send, iolist_to_binary(Data)}, State);
 
 handle_cast({send, Data}, #state{sock=Sock}=State) when is_binary(Data) ->
-    ?debug("unix send(~p)~n", [Data]),
+    %%?debug("unix send(~p)~n", [Data]),
     gen_tcp:send(Sock, Data),
     {noreply, State};
 
@@ -97,7 +97,7 @@ handle_cast(Request, State) ->
     {noreply, State}.
 
 handle_info({unix, Data}, #state{owner=Owner}=State) ->
-    ?debug("unix received(~p)~n", [Data]),
+    %%?debug("unix received(~p)~n", [Data]),
     Owner ! {received, Data},
     {noreply, State};
 

--- a/src/dbus_transport_unix.erl
+++ b/src/dbus_transport_unix.erl
@@ -35,7 +35,12 @@
 connect(BusOptions, _Options) ->
     Path = case proplists:get_value(path, BusOptions) of
 	       undefined ->
-                   throw(no_path);
+                   case proplists:get_value(abstract, BusOptions) of
+                       undefined ->
+                           throw(no_path);
+                       V ->
+                           <<0, (list_to_binary(V))/binary>>
+                   end;
 	       V ->
 		   list_to_binary(V)
 	   end,

--- a/src/dbus_transport_unix.erl
+++ b/src/dbus_transport_unix.erl
@@ -52,9 +52,7 @@ connect(BusOptions, _Options) ->
 init([Path, Owner]) when is_pid(Owner), is_binary(Path) ->
     true = link(Owner),
     ?debug("Connecting to UNIX socket: ~p~n", [Path]),
-    {ok, S} = prim_inet:open(tcp, local, stream),
-    {ok, Fd} = prim_inet:getfd(S),
-    case gen_tcp:connect({local, Path}, 0, [{fd, Fd}, {recbuf, 65535}]) of
+    case gen_tcp:connect({local, Path}, 0, [local, {recbuf, 65535}]) of
 	{ok, Sock} ->
             Loop = spawn_link(?MODULE, do_read, [Sock, self()]),
             gen_tcp:controlling_process(Sock, Loop),

--- a/src/dbus_transport_unix.erl
+++ b/src/dbus_transport_unix.erl
@@ -32,8 +32,6 @@
 		loop     :: pid(),
 		raw      :: boolean()}).
 
--define(DEFAULT_PATH, "/tmp/erlang-dbus").
-
 connect(BusOptions, _Options) ->
     Path = case proplists:get_value(path, BusOptions) of
 	       undefined ->


### PR DESCRIPTION
So this PR is based on #23 plus fixes for test and including Erlang 19.0 to the build list.

There is one slight problem which I couldn't figure out and it's when I use 

```
{ok, Bus} = dbus_bus_connection:connect(session)
```

The problem is that the socket is create for a user session is `abstract address` it's something like :
```
unix:abstract=/tmp/dbus-cNsBK4GIj1
```

I'm waiting for an answer in erlang/otp/pull/612 to find out how to deal with connection to abstract address 