### PR TITLE
Fix typo

### DIFF
--- a/src/dbus_proxy.erl
+++ b/src/dbus_proxy.erl
@@ -102,7 +102,7 @@ stop(Proxy) ->
     gen_server:cast(Proxy, stop).
 
 
-%% @equiv call(Proxy. Msg, 5000).
+%% @equiv call(Proxy, Msg, 5000)
 %% @end
 -spec call(Proxy :: dbus_proxy(), Msg :: dbus_message()) -> {ok, term()} | {error, term()}.
 call(Proxy, #dbus_message{}=Msg) ->


### PR DESCRIPTION
This patch just fixes typo introduced in commit 4d737b6427ecf78ec3301d0de77196bd7ad9cf8c.

Signed-off-by: Peter Lemenkov <lemenkov@gmail.com>