### PR TITLE
Fix reception of large responses coming in pieces

### DIFF
--- a/src/dbus_peer_connection.erl
+++ b/src/dbus_peer_connection.erl
@@ -273,7 +273,8 @@ handle_info({received, Bin}, waiting_for_agree, State) ->
 
 %% STATE: authenticated
 handle_info({received, Data}, authenticated, #state{buf=Buf}=State) ->
-    case dbus_marshaller:unmarshal_data(<<Buf/binary, Data/binary>>) of
+    BufAndData = <<Buf/binary, Data/binary>>,
+    case dbus_marshaller:unmarshal_data(BufAndData) of
         {ok, Msgs, Rest} ->
             case handle_messages(Msgs, State#state{buf=Rest}) of
                 {ok, State2} ->
@@ -282,7 +283,7 @@ handle_info({received, Data}, authenticated, #state{buf=Buf}=State) ->
                     {stop, {error, Err}, State2}
             end;
         more ->
-            {next_state, authenticated, State#state{buf=Data}}
+            {next_state, authenticated, State#state{buf=BufAndData}}
     end;
 
 %% Other


### PR DESCRIPTION
Bug encountered when receiving ~139kB size introspection XML data from Pidgin.

```
Introspecting: "im.pidgin.purple.PurpleService":"/im/pidgin/purple/PurpleObject"

17:55:54.188 [info]  Bad message header: "ection='in'/>\n      <arg name='msg' type='s' direction='in'/>\n (...)"
```

To reproduce, type in (Elixir):
```elixir
{:ok, bus} = :dbus_bus_connection.connect(:session)
{:ok, purple} = :dbus_proxy.start_link(bus, "im.pidgin.purple.PurpleService", "/im/pidgin/purple/PurpleObject")
```