### PR TITLE
Fix introspection issues observed with QT cpp dbus services

### DIFF
--- a/.github/workflows/erlang.yml
+++ b/.github/workflows/erlang.yml
@@ -14,7 +14,7 @@ jobs:
     - name: Install dependencies
       run: |
         sudo apt-get update
-        sudo apt-get install -y dbus python3-gi python3-dbus erlang
+        sudo apt-get install -y dbus python3-gi python3-dbus qtbase5-dev erlang
 
     - name: Compile
       run: |

--- a/.github/workflows/erlang.yml
+++ b/.github/workflows/erlang.yml
@@ -1,5 +1,9 @@
 name: "Erlang CI"
-on: ["push", "pull_request"]
+on:
+  push:
+    branches:
+      - master
+  pull_request:
 
 jobs:
   build:
@@ -22,3 +26,12 @@ jobs:
         make eunit
         dbus-run-session --config-file=demo/test/session.conf -- make -C demo eunit
 
+    - name: Run CT
+      run: |
+        make ct
+    - name: Upload ct logs
+      uses: actions/upload-artifact@v4
+      if: always()
+      with:
+        name: ct_logs
+        path: logs

--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,8 @@
 
 # EDTS
 .edts
+
+# Build artifacts for cpp test client
+/test/dbus_client_SUITE_data/example-service/*
+!/test/dbus_client_SUITE_data/example-service/main.cpp
+!/test/dbus_client_SUITE_data/example-service/example-service.pro

--- a/Makefile
+++ b/Makefile
@@ -8,3 +8,16 @@ dep_hexer_mk = git https://github.com/inaka/hexer.mk.git 1.1.0
 DEP_PLUGINS = hexer_mk
 
 include $(if $(ERLANG_MK_FILENAME),$(ERLANG_MK_FILENAME),erlang.mk)
+
+## For building and cleaning the cpp based example service automatically
+
+test-build:: test/dbus_client_SUITE_data/example-service/example-service
+
+clean::
+	@[ ! -f test/dbus_client_SUITE_data/example-service/Makefile ] || $(MAKE) -C test/dbus_client_SUITE_data/example-service distclean
+
+test/dbus_client_SUITE_data/example-service/Makefile: test/dbus_client_SUITE_data/example-service/main.cpp test/dbus_client_SUITE_data/example-service/example-service.pro
+	cd test/dbus_client_SUITE_data/example-service && qmake
+
+test/dbus_client_SUITE_data/example-service/example-service: test/dbus_client_SUITE_data/example-service/Makefile
+	$(MAKE) -C test/dbus_client_SUITE_data/example-service

--- a/README.md
+++ b/README.md
@@ -94,7 +94,6 @@ The status:
 * Connect through TCP and UNIX socket: ok
 
 ### TODO
-* Figure out why `make ct` tests don't run on github actions
 * Fix signal emission from services
 * Make dializer happy
 * Some authentication mechanisms are not implemented, but architectures allows for easy extension (see https://github.com/lizenn/erlang-dbus/blob/master/src/dbus_auth_cookie_sha1.erl, https://github.com/lizenn/erlang-dbus/blob/master/src/dbus_auth_external.erl and https://github.com/lizenn/erlang-dbus/blob/master/src/dbus_auth_anonymous.erl)

--- a/src/dbus_introspect.erl
+++ b/src/dbus_introspect.erl
@@ -294,19 +294,19 @@ xml_event({endElement, _, "node", _}, _L, #state{s=child_node, node=#dbus_node{e
     S#state{s=node, node=N#dbus_node{elements=[C | E]}, child=undefined};
 
 xml_event({endElement, _, "interface", _}, _L, #state{s=iface, node=#dbus_node{interfaces=Ifaces}=N, iface=I}=S) ->
-    NewNode = N#dbus_node{interfaces=gb_trees:insert(I#dbus_iface.name, I, Ifaces)},
+    NewNode = N#dbus_node{interfaces=gb_trees:enter(I#dbus_iface.name, I, Ifaces)},
     S#state{s=node, node=NewNode, iface=undefined, method=undefined};
 
 xml_event({endElement, _, "method", _}, _L, #state{s=method, iface=#dbus_iface{methods=Methods}=I, method=M}=S) ->
-    NewIface = I#dbus_iface{methods=gb_trees:insert(M#dbus_method.name, end_method(M), Methods)},
+    NewIface = I#dbus_iface{methods=gb_trees:enter(M#dbus_method.name, end_method(M), Methods)},
     S#state{s=iface, iface=NewIface, method=undefined};
 
 xml_event({endElement, _, "signal", _}, _L, #state{s=signal, iface=#dbus_iface{signals=Signals}=I, signal=Sig}=S) ->
-    NewIface = I#dbus_iface{signals=gb_trees:insert(Sig#dbus_signal.name, end_signal(Sig), Signals)},
+    NewIface = I#dbus_iface{signals=gb_trees:enter(Sig#dbus_signal.name, end_signal(Sig), Signals)},
     S#state{s=iface, iface=NewIface, signal=undefined};
 
 xml_event({endElement, _, "property", _}, _L, #state{s=property, iface=#dbus_iface{properties=Props}=I, property=P}=S) ->
-    NewIface = I#dbus_iface{properties=gb_trees:insert(P#dbus_property.name, P, Props)},
+    NewIface = I#dbus_iface{properties=gb_trees:enter(P#dbus_property.name, P, Props)},
     S#state{s=iface, iface=NewIface, property=undefined};
 
 xml_event({endElement, _, "arg", _}, _L, #state{s=method_arg}=S) ->

--- a/src/dbus_proxy.erl
+++ b/src/dbus_proxy.erl
@@ -400,7 +400,7 @@ do_introspect(Conn, Service, Path) ->
     ?debug("Introspecting: ~p:~p~n", [Service, Path]),
     case dbus_connection:call(Conn, dbus_message:introspect(Service, Path)) of
         {ok, #dbus_message{body=Xml}} when is_binary(Xml) ->
-            try dbus_introspect:from_xml_string(Xml) of
+            try dbus_introspect:from_xml_string(Xml, Path) of
                 #dbus_node{}=Node -> {ok, Node}
             catch _:Err ->
                     ?error("Error parsing introspection infos: ~p~n", [Err]),

--- a/test/dbus_client_SUITE.erl
+++ b/test/dbus_client_SUITE.erl
@@ -80,6 +80,7 @@ init_per_group(connect_tcp_anonymous, Config) ->
 init_per_group(connect_unix_anonymous, Config) ->
     start_dbus(Config, ?dbus_session_unix_anonymous);
 init_per_group(connect_unix_external, Config) ->
+    application:set_env(dbus, external_cookie, system_user),
     start_dbus(Config, ?dbus_session_unix_external);
 init_per_group(_Name, Config) ->
     Config0 = start_dbus(Config, ?dbus_session_unix_external),

--- a/test/dbus_client_SUITE_data/example-service.py
+++ b/test/dbus_client_SUITE_data/example-service.py
@@ -15,16 +15,16 @@ class SampleObject(dbus.service.Object):
         print (str(hello_message))
         self.SampleSignal(42, 24)
         self.SampleSignal2()
-        return ["Hello World", " from example-service.py"]
+        return ["Hello World", " from example-service"]
 
     @dbus.service.method("net.lizenn.dbus.SampleInterface",
                          out_signature='as')
     def GetTuple(self):
-        return ("Hello Tuple", " from example-service.py")
+        return ("Hello Tuple", " from example-service")
 
     @dbus.service.method("net.lizenn.dbus.SampleInterface")
     def GetDict(self):
-        return {"first": "Hello Dict", "second": " from example-service.py"}
+        return {"first": "Hello Dict", "second": " from example-service"}
 
     @dbus.service.method("net.lizenn.dbus.SampleInterface", in_signature='u')
     def GetString(self, size):

--- a/test/dbus_client_SUITE_data/example-service/example-service.pro
+++ b/test/dbus_client_SUITE_data/example-service/example-service.pro
@@ -1,0 +1,9 @@
+QT += core dbus
+QT -= gui
+
+TARGET = example-service
+CONFIG += console
+CONFIG -= app_bundle
+
+TEMPLATE = app
+SOURCES += main.cpp

--- a/test/dbus_client_SUITE_data/example-service/main.cpp
+++ b/test/dbus_client_SUITE_data/example-service/main.cpp
@@ -1,0 +1,66 @@
+#include <QCoreApplication>
+#include <QtDBus/QtDBus>
+#include <QDebug>
+
+class SampleObject : public QObject
+{
+    Q_OBJECT
+    Q_CLASSINFO("D-Bus Interface", "net.lizenn.dbus.SampleInterface")
+
+public:
+    SampleObject(QObject *parent = nullptr) : QObject(parent) {}
+
+public slots:
+    Q_SCRIPTABLE QStringList HelloWorld(const QString &helloMessage) {
+        qDebug() << helloMessage;
+        emit SampleSignal(42, 24);
+        emit SampleSignal2();
+        return QStringList() << "Hello World" << " from example-service";
+    }
+
+    Q_SCRIPTABLE QStringList GetTuple() {
+        return QStringList() << "Hello Tuple" << " from example-service";
+    }
+
+    Q_SCRIPTABLE QVariantMap GetDict() {
+        QVariantMap map;
+        map["first"] = "Hello Dict";
+        map["second"] = " from example-service";
+        return map;
+    }
+
+    Q_SCRIPTABLE QString GetString(uint size) {
+        return QString(size, 'x');
+    }
+
+signals:
+    Q_SCRIPTABLE void SampleSignal(int x, int y);
+    Q_SCRIPTABLE void SampleSignal2();
+};
+
+int main(int argc, char *argv[])
+{
+    QCoreApplication app(argc, argv);
+
+    if (!QDBusConnection::sessionBus().isConnected()) {
+        qCritical() << "Cannot connect to the D-Bus session bus";
+        return 1;
+    }
+
+    if (!QDBusConnection::sessionBus().registerService("net.lizenn.dbus.SampleService")) {
+        qCritical() << "Cannot register the service:" << QDBusConnection::sessionBus().lastError().message();
+        return 1;
+    }
+
+    SampleObject root, child1, little1, little2;
+
+    QDBusConnection::sessionBus().registerObject("/root", &root, QDBusConnection::ExportAllContents);
+    QDBusConnection::sessionBus().registerObject("/root/child1", &child1, QDBusConnection::ExportAllContents);
+    QDBusConnection::sessionBus().registerObject("/root/child2/little1", &little1, QDBusConnection::ExportAllContents);
+    QDBusConnection::sessionBus().registerObject("/root/child2/little2", &little2, QDBusConnection::ExportAllContents);
+
+    qDebug() << "Service started";
+    return app.exec();
+}
+
+#include "main.moc"

--- a/test/dbus_client_SUITE_data/example-service/main.cpp
+++ b/test/dbus_client_SUITE_data/example-service/main.cpp
@@ -22,6 +22,10 @@ public slots:
         return QStringList() << "Hello Tuple" << " from example-service";
     }
 
+    Q_SCRIPTABLE QStringList GetTuple(const QString &message) {
+        return QStringList() << message << " from example-service";
+    }
+
     Q_SCRIPTABLE QVariantMap GetDict() {
         QVariantMap map;
         map["first"] = "Hello Dict";

--- a/test/dbus_client_SUITE_data/session_tcp_anonymous.conf
+++ b/test/dbus_client_SUITE_data/session_tcp_anonymous.conf
@@ -7,7 +7,8 @@
   <listen>tcp:host=localhost,bind=*,port=55555,family=ipv4</listen>
   <auth>ANONYMOUS</auth>
   <allow_anonymous/>
-  
+  <apparmor mode="disabled"/>
+
   <standard_session_servicedirs />
 
   <policy context="default">


### PR DESCRIPTION
I've split this into four commits:

1. Fix and run CT on GitHub Actions
2. Add an example c++ service using QT DBus (tests fail on this commit)
3. Fix missing name attribute for root node in introspection results (fix above failure) - #44
4. Don't crash when introspecting an object with overloaded methods (add the testcase for overloaded methods, and fix the issue) - #43

There can be multiple alternative ways to fix things here, but I've raised the PR based on my understanding of the code base. Let me know if you need me to do things in a different way.